### PR TITLE
CLS: Add the ability to safely use multiple sequelize instances

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -202,7 +202,7 @@ ConnectionManager.prototype.getConnection = function(options) {
     } else {
       promise = this.versionPromise = self.$connect(self.config.replication.write || self.config).then(function (connection) {
         var _options = {};
-        _options.transaction = { connection: connection }; // Cheat .query to use our private connection
+        _options.transaction = { connection: connection, sequelize: self.sequelize }; // Cheat .query to use our private connection
         _options.logging = function () {};
         _options.logging.__testLoggingFn = true;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1897,7 +1897,7 @@ Model.prototype.findOrCreate = function(options) {
 
   options = _.assign({}, options);
 
-  if (options.transaction === undefined && this.sequelize.constructor.cls) {
+  if (options.transaction === undefined && this.sequelize.options.useCLS && this.sequelize.constructor.cls) {
     var t = this.sequelize.constructor.cls.get('transaction');
     if (t) {
       options.transaction = t;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -79,6 +79,7 @@ var url = require('url')
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
+ * @param {Boolean}  [options.useCLS=true] Use CLS namespace to share transactions, when available.
  * @param {Object}   [options.pool={}] Should sequelize use a connection pool. Default is true
  * @param {Integer}  [options.pool.maxConnections]
  * @param {Integer}  [options.pool.minConnections]
@@ -170,7 +171,8 @@ var Sequelize = function(database, username, password, options) {
     isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
     databaseVersion: 0,
     typeValidation: false,
-    benchmark: false
+    benchmark: false,
+    useCLS: true
   }, options || {});
 
   if (this.options.dialect === 'postgresql') {
@@ -807,8 +809,20 @@ Sequelize.prototype.query = function(sql, options) {
     searchPath: this.options.hasOwnProperty('searchPath') ? this.options.searchPath : 'DEFAULT',
   });
 
-  if (options.transaction === undefined && Sequelize.cls) {
+  var usingClsTransaction = false;
+  if (options.transaction === undefined && this.options.useCLS && Sequelize.cls) {
     options.transaction = Sequelize.cls.get('transaction');
+    if (options.transaction) {
+      usingClsTransaction = true;
+    }
+  }
+
+  if (options.transaction && options.transaction.sequelize !== this) {
+    var errorMessage = 'Cannot query with a transaction created by another Sequelize instance';
+    if (usingClsTransaction) {
+      errorMessage += ' (transaction obtained from CLS)';
+    }
+    throw new Error(errorMessage);
   }
 
   if (!options.type) {
@@ -1277,7 +1291,7 @@ Sequelize.prototype.transaction = function(options, autoCallback) {
   // testhint argsConform.end
 
   var transaction = new Transaction(this, options)
-    , ns = Sequelize.cls;
+    , ns = this.options.useCLS ? Sequelize.cls : null;
 
   if (autoCallback) {
     var transactionResolver = function (resolve, reject) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -239,7 +239,7 @@ Transaction.prototype.prepareEnvironment = function() {
       throw setupErr;
     });
   }).tap(function () {
-    if (self.sequelize.constructor.cls) {
+    if (self.sequelize.options.useCLS && self.sequelize.constructor.cls) {
       self.sequelize.constructor.cls.set('transaction', self);
     }
     return null;
@@ -283,7 +283,7 @@ Transaction.prototype.cleanup = function() {
 };
 
 Transaction.prototype.$clearCls = function () {
-  var cls = this.sequelize.constructor.cls;
+  var cls = this.sequelize.options.useCLS ? this.sequelize.constructor.cls : null;
 
   if (cls) {
     if (cls.get('transaction') === this) {

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -8,10 +8,17 @@ var chai      = require('chai')
   , Sequelize = Support.Sequelize
   , Promise   = Sequelize.Promise
   , cls       = require('continuation-local-storage')
+  , sinon     = require('sinon')
   , current = Support.sequelize;
 
 if (current.dialect.supports.transactions) {
   describe(Support.getTestDialectTeaser('Continuation local storage'), function () {
+    beforeEach(function () {
+      this.sinon = sinon.sandbox.create();
+    });
+    afterEach(function() {
+      this.sinon.restore();
+    });
     before(function () {
       Sequelize.cls = cls.createNamespace('sequelize');
     });
@@ -143,6 +150,47 @@ if (current.dialect.supports.transactions) {
         });
       });
     });
+
+    describe('with useCLS=false', function() {
+      beforeEach(function() {
+        this.sequelize = Support.createSequelizeInstance({ useCLS: false });
+        this.User = this.sequelize.define('user', {
+          name: Sequelize.STRING
+        });
+      });
+
+      it('does not use CLS to share transactions', function () {
+        var self = this;
+        return this.sequelize.transaction(function (t) {
+          return self.User.create({ name: 'bob' }, { transaction: t }).then(function () {
+            return expect(self.User.findAll()).to.eventually.have.length(0);
+          });
+        });
+      });
+    });
+
+    describe('multiple sequelize instances', function() {
+      var secondSequelize;
+      beforeEach(function() {
+        secondSequelize = Support.createSequelizeInstance();
+      });
+
+      it('throws instead of sharing transactions between instances', function() {
+        var self = this;
+        return this.sequelize.transaction(function (t) {
+          var transctionQuerySpy = self.sinon.spy(t.connection, 'query');
+          return self.sequelize.query('SELECT 1;').then(function() {
+            expect(transctionQuerySpy).to.have.been.calledWith('SELECT 1;');
+          }).then(function() {
+            var queryPromise = new Promise(function() {
+              return secondSequelize.query('SELECT 2;');
+            });
+            return expect(queryPromise).to.be.eventually
+              .rejectedWith('Cannot query with a transaction created by another Sequelize instance (transaction obtained from CLS)');
+          });
+        });
+      });
+    })
 
     describe('bluebird shims', function () {
       beforeEach(function () {


### PR DESCRIPTION
* Previously, enabling CLS when using multiple sequelize instances would
  cause them to silently share transactions (connections), potentially executing against the wrong database instance.
* This PR makes two changes to address this:
* (1) `sequelize.query` asserts that any transaction it uses was created by its own instance and no other.
* (2) add a new `options.useCLS` sequelize option, so that individual sequelize instances can choose to not participate in CLS for transactions.