### PR TITLE
Revert "CLS: Add the ability to safely use multiple sequelize instances"

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -202,7 +202,7 @@ ConnectionManager.prototype.getConnection = function(options) {
     } else {
       promise = this.versionPromise = self.$connect(self.config.replication.write || self.config).then(function (connection) {
         var _options = {};
-        _options.transaction = { connection: connection, sequelize: self.sequelize }; // Cheat .query to use our private connection
+        _options.transaction = { connection: connection }; // Cheat .query to use our private connection
         _options.logging = function () {};
         _options.logging.__testLoggingFn = true;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1897,7 +1897,7 @@ Model.prototype.findOrCreate = function(options) {
 
   options = _.assign({}, options);
 
-  if (options.transaction === undefined && this.sequelize.options.useCLS && this.sequelize.constructor.cls) {
+  if (options.transaction === undefined && this.sequelize.constructor.cls) {
     var t = this.sequelize.constructor.cls.get('transaction');
     if (t) {
       options.transaction = t;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -79,7 +79,6 @@ var url = require('url')
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
- * @param {Boolean}  [options.useCLS=true] Use CLS namespace to share transactions, when available.
  * @param {Object}   [options.pool={}] Should sequelize use a connection pool. Default is true
  * @param {Integer}  [options.pool.maxConnections]
  * @param {Integer}  [options.pool.minConnections]
@@ -171,8 +170,7 @@ var Sequelize = function(database, username, password, options) {
     isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
     databaseVersion: 0,
     typeValidation: false,
-    benchmark: false,
-    useCLS: true
+    benchmark: false
   }, options || {});
 
   if (this.options.dialect === 'postgresql') {
@@ -809,20 +807,8 @@ Sequelize.prototype.query = function(sql, options) {
     searchPath: this.options.hasOwnProperty('searchPath') ? this.options.searchPath : 'DEFAULT',
   });
 
-  var usingClsTransaction = false;
-  if (options.transaction === undefined && this.options.useCLS && Sequelize.cls) {
+  if (options.transaction === undefined && Sequelize.cls) {
     options.transaction = Sequelize.cls.get('transaction');
-    if (options.transaction) {
-      usingClsTransaction = true;
-    }
-  }
-
-  if (options.transaction && options.transaction.sequelize !== this) {
-    var errorMessage = 'Cannot query with a transaction created by another Sequelize instance';
-    if (usingClsTransaction) {
-      errorMessage += ' (transaction obtained from CLS)';
-    }
-    throw new Error(errorMessage);
   }
 
   if (!options.type) {
@@ -1291,7 +1277,7 @@ Sequelize.prototype.transaction = function(options, autoCallback) {
   // testhint argsConform.end
 
   var transaction = new Transaction(this, options)
-    , ns = this.options.useCLS ? Sequelize.cls : null;
+    , ns = Sequelize.cls;
 
   if (autoCallback) {
     var transactionResolver = function (resolve, reject) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -239,7 +239,7 @@ Transaction.prototype.prepareEnvironment = function() {
       throw setupErr;
     });
   }).tap(function () {
-    if (self.sequelize.options.useCLS && self.sequelize.constructor.cls) {
+    if (self.sequelize.constructor.cls) {
       self.sequelize.constructor.cls.set('transaction', self);
     }
     return null;
@@ -283,7 +283,7 @@ Transaction.prototype.cleanup = function() {
 };
 
 Transaction.prototype.$clearCls = function () {
-  var cls = this.sequelize.options.useCLS ? this.sequelize.constructor.cls : null;
+  var cls = this.sequelize.constructor.cls;
 
   if (cls) {
     if (cls.get('transaction') === this) {


### PR DESCRIPTION
This reverts commit 094bdeb5d3a22c276e614fb2314956626000dccb.

This was added to support multiple sequelize instances in one code base. We don't need that anymore, so let's undo this forkage.