### PR TITLE
Manually apply https://github.com/sequelize/sequelize/pull/8430

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1312,7 +1312,7 @@ Sequelize.prototype.transaction = function(options, autoCallback) {
 
     return new Promise(transactionResolver);
   } else {
-    return transaction.prepareEnvironment().return(transaction);
+    return transaction.prepareEnvironment(false).return(transaction);
   }
 };
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -218,7 +218,10 @@ Transaction.prototype.rollback = function() {
     });
 };
 
-Transaction.prototype.prepareEnvironment = function() {
+Transaction.prototype.prepareEnvironment = function(useCLS) {
+  if (typeof useCLS === 'undefined') {
+    useCLS = true;
+  }
   var self = this;
 
   return Utils.Promise.resolve(
@@ -239,7 +242,7 @@ Transaction.prototype.prepareEnvironment = function() {
       throw setupErr;
     });
   }).tap(function () {
-    if (self.sequelize.constructor.cls) {
+    if (useCLS && self.sequelize.constructor.cls) {
       self.sequelize.constructor.cls.set('transaction', self);
     }
     return null;


### PR DESCRIPTION
Unmanaged transactions will create transaction leaks.
We don't directly use unmanaged transactions but they appear to happen under-the-hood in Sequelize under certain model calls. I confirmed this by added a `trace` and running the `PricingDataExportTask` (where we've had errors like `SET TRANSACTION must be called before other queries` which should only be possible if the transactions are leaking).

```
Trace: SOMETHING IS NOT USING AN AUTOCALLBACK
    at module.exports.Transaction.prepareEnvironment (/Users/owen/workspace/shipotle-api/node_modules/sequelize/lib/transaction.js:22
8:15)
    at Sequelize.transaction (/Users/owen/workspace/shipotle-api/node_modules/sequelize/lib/sequelize.js:1315:24)
    at Sequelize.transaction (/Users/owen/workspace/shipotle-api/dist/app/models/models.js:147:34)
    at Model.findOrCreate (/Users/owen/workspace/shipotle-api/node_modules/sequelize/lib/model.js:1917:25)
    at Model.updateAttribute (/Users/owen/workspace/shipotle-api/dist/app/models/DerivedShipmentAttribute.js:28:48)
    at Instance.updateOrCreateSupplyAvailabilityScore (/Users/owen/workspace/shipotle-api/dist/app/models/Shipment.js:2194:66)
```

This has created at least [one explicit error](https://sentry.io/organizations/convoy/issues/830424488/?project=41908&query=SET+TRANSACTION&statsPeriod=90d&utc=false) in production but potentially other data corruption issues.

Tested by running the Shipotle API tests against this branch. https://circleci.com/workflow-run/1beaffca-7f1f-4123-885e-5ed4116ff92d