### PR TITLE
Apply performance patches to Sequelize 3

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,7 @@
   "boss":true,
   "curly":false,
   "eqeqeq":true,
+  "esversion": 6,
   "freeze":true,
   "immed":true, // deprecated
   "indent":2, // deprecated

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -272,7 +272,7 @@ HasMany.prototype.get = function(instances, options) {
     instances = undefined;
   }
 
-  options = Utils.cloneDeep(options) || {};
+  options = Object.assign({}, options);
 
   if (association.scope) {
     _.assign(where, association.scope);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -332,7 +332,7 @@ var QueryGenerator = {
 
     var query = 'INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %><%= onConflict %><%= onDuplicateKeyUpdate %><%= returning %>;'
       , tuples = []
-      , serials = []
+      , serials = {}
       , allAttributes = []
       , onDuplicateKeyUpdate = ''
       , onConflict = '';
@@ -344,7 +344,7 @@ var QueryGenerator = {
         }
 
         if (rawAttributes[key] && rawAttributes[key].autoIncrement === true) {
-          serials.push(key);
+          serials[key] = true;
         }
       });
     });
@@ -352,7 +352,7 @@ var QueryGenerator = {
     attrValueHashes.forEach(function(attrValueHash) {
       tuples.push('(' +
         allAttributes.map(function(key) {
-          if (this._dialect.supports.bulkDefault && serials.indexOf(key) !== -1) {
+          if (this._dialect.supports.bulkDefault && serials[key] === true) {
             return attrValueHash[key] || 'DEFAULT';
           }
           return this.escape(attrValueHash[key], rawAttributes[key], { context: 'INSERT' });

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -167,6 +167,7 @@ var groupJoinData = function(rows, includeOptions, options) {
     , uniqueKeyAttributes
     , prefix;
 
+  const stringify = obj => obj instanceof Buffer ? obj.toString('hex') : obj;
   for (rowsI = 0; rowsI < rowsLength; rowsI++) {
     row = rows[rowsI];
 
@@ -183,11 +184,11 @@ var groupJoinData = function(rows, includeOptions, options) {
       $length = includeOptions.model.primaryKeyAttributes.length;
       topHash = '';
       if ($length === 1) {
-        topHash = row[includeOptions.model.primaryKeyAttributes[0]];
+        topHash = stringify(row[includeOptions.model.primaryKeyAttributes[0]]);
       }
       else if ($length > 1) {
         for ($i = 0; $i < $length; $i++) {
-          topHash += row[includeOptions.model.primaryKeyAttributes[$i]];
+          topHash += stringify(row[includeOptions.model.primaryKeyAttributes[$i]]);
         }
       }
       else if (!Utils._.isEmpty(includeOptions.model.uniqueKeys)) {
@@ -235,11 +236,11 @@ var groupJoinData = function(rows, includeOptions, options) {
               $length = primaryKeyAttributes.length;
               itemHash = prefix;
               if ($length === 1) {
-                itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+                itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
               }
               else if ($length > 1) {
                 for ($i = 0; $i < $length; $i++) {
-                  itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+                  itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
                 }
               }
               else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
@@ -322,11 +323,11 @@ var groupJoinData = function(rows, includeOptions, options) {
           $length = primaryKeyAttributes.length;
           itemHash = prefix;
           if ($length === 1) {
-            itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+            itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
           }
           else if ($length > 0) {
             for ($i = 0; $i < $length; $i++) {
-              itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+              itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
             }
           }
           else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -102,7 +102,7 @@ var groupJoinData = function(rows, includeOptions, options) {
       if ($current.includeMap[piece]) {
         includeMap[key] = $current = $current.includeMap[piece];
         if (previousPiece) {
-          previousPiece = previousPiece+'.'+piece;
+          previousPiece = `${previousPiece}.${piece}`;
         } else {
           previousPiece = piece;
         }
@@ -153,7 +153,7 @@ var groupJoinData = function(rows, includeOptions, options) {
     , getUniqueKeyAttributes = function (model) {
         var uniqueKeyAttributes = Utils._.chain(model.uniqueKeys);
         uniqueKeyAttributes = uniqueKeyAttributes
-        .result(uniqueKeyAttributes.findKey() + '.fields')
+        .result(`${uniqueKeyAttributes.findKey()}.fields`)
         .map(function(field){
           return Utils._.findKey(model.attributes, function(chr) {
             return chr.field === field;
@@ -231,22 +231,22 @@ var groupJoinData = function(rows, includeOptions, options) {
 
           if (length) {
             for (i = 0; i < length; i++) {
-              prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+              prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
               primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
               $length = primaryKeyAttributes.length;
               itemHash = prefix;
               if ($length === 1) {
-                itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
+                itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
               }
               else if ($length > 1) {
                 for ($i = 0; $i < $length; $i++) {
-                  itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
+                  itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
                 }
               }
               else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
                 uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
                 for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-                  itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+                  itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
                 }
               }
               if (!parentHash) {
@@ -318,22 +318,22 @@ var groupJoinData = function(rows, includeOptions, options) {
 
       if (length) {
         for (i = 0; i < length; i++) {
-          prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+          prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
           primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
           $length = primaryKeyAttributes.length;
           itemHash = prefix;
           if ($length === 1) {
-            itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
+            itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
           }
           else if ($length > 0) {
             for ($i = 0; $i < $length; $i++) {
-              itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
+              itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
             }
           }
           else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
             uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
             for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-              itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+              itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
             }
           }
           if (!parentHash) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1447,7 +1447,10 @@ Model.$findSeparate = function(results, options) {
           // Force array so we can concat no matter if it's 1:1 or :M
           if (!Array.isArray(associations)) associations = [associations];
 
-          return memo.concat(associations);
+          for (let i = 0, len = associations.length; i !== len; ++i) {
+            memo.push(associations[i]);
+          }
+          return memo;
         }, []),
         _.assign(
           {},

--- a/lib/model.js
+++ b/lib/model.js
@@ -1351,8 +1351,7 @@ Model.prototype.findAll = function(options) {
   if (arguments.length > 1) {
     throw new Error('Please note that find* was refactored and uses only one options object from now on.');
   }
-  var tableNames = {}
-    , originalOptions;
+  var tableNames = {};
 
   tableNames[this.getTableName(options)] = true;
   options = Utils.cloneDeep(options);
@@ -1403,9 +1402,8 @@ Model.prototype.findAll = function(options) {
       return this.runHooks('beforeFindAfterOptions', options);
     }
   }).then(function() {
-    originalOptions = Utils.cloneDeep(options);
-    options.tableNames = Object.keys(tableNames);
-    return this.QueryInterface.select(this, this.getTableName(options), options);
+    const selectOptions = Object.assign({}, options, { tableNames: Object.keys(tableNames) });
+    return this.QueryInterface.select(this, this.getTableName(selectOptions), selectOptions);
   }).tap(function(results) {
     if (options.hooks) {
       return this.runHooks('afterFind', results, options);
@@ -1423,7 +1421,7 @@ Model.prototype.findAll = function(options) {
       }
     }
 
-    return Model.$findSeparate(results, originalOptions);
+    return Model.$findSeparate(results, options);
   });
 };
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -662,10 +662,8 @@ QueryInterface.prototype.bulkDelete = function(tableName, identifier, options, m
   return this.sequelize.query(sql, options);
 };
 
-QueryInterface.prototype.select = function(model, tableName, options) {
-  options = Utils.cloneDeep(options);
-  options.type = QueryTypes.SELECT;
-  options.model = model;
+QueryInterface.prototype.select = function(model, tableName, optionsArg) {
+  const options = Object.assign({}, optionsArg, { type: QueryTypes.SELECT, model });
 
   return this.sequelize.query(
     this.QueryGenerator.selectQuery(tableName, options, model),


### PR DESCRIPTION
I found a few performance patches that might improve Sequelize perf. The bulkInsert one is a pretty big gain but probably not related to what we're seeing. Otherwise, there's seems to be ~10% improvement but may be more improved in production where we have some degenerate cases.

For comparison, I ran Sequelize's benchmarks:
```

Control:
Owens-MacBook-Pro:sequelize owen$ DIALECT=postgres sequelize-benchmark
  sequelize:perf Using postgres DIALECT. +0ms
(node:65740) DeprecationWarning: Using the automatically created return value from client.query as an event emitter is deprecated and will be removed in pg@7.0. Please see the upgrade guide at https://node-postgres.com/guides/upgrading
  sequelize:perf Env ready +212ms
  sequelize:perf Starting findAll +8s
  sequelize:perf finding 1500 rows x 1.73 ops/sec ±2.55% (13 runs sampled) (mean 0.577634s) +8s
  sequelize:perf finding(raw) 1500 rows x 1.82 ops/sec ±0.88% (13 runs sampled) (mean 0.550458s) +7s
  sequelize:perf finding(plain) 1500 rows x 1.79 ops/sec ±1.53% (13 runs sampled) (mean 0.557214s) +7s
  sequelize:perf finding 1500 rows with join x 1.73 ops/sec ±0.69% (13 runs sampled) (mean 0.578711s) +8s
  sequelize:perf finding 1500 rows with join (heavy includes) x 1.53 ops/sec ±1.61% (12 runs sampled) (mean 0.652015s) +8s
  sequelize:perf finding 10 rows x 124 ops/sec ±0.65% (80 runs sampled) (mean 0.008034s) +6s
  sequelize:perf finding(raw) 10 rows x 128 ops/sec ±0.59% (82 runs sampled) (mean 0.007800s) +6s
  sequelize:perf finding(plain) 10 rows x 127 ops/sec ±1.22% (81 runs sampled) (mean 0.007878s) +6s
  sequelize:perf finding 10 rows with join x 116 ops/sec ±1.14% (76 runs sampled) (mean 0.008637s) +6s
  sequelize:perf Starting bulkCreate +74ms
  sequelize:perf inserting 10000 rows x 1.21 ops/sec ±1.05% (11 runs sampled) (mean 0.824985s) +9s
  sequelize:perf inserting 1000 rows x 17.05 ops/sec ±6.33% (43 runs sampled) (mean 0.058662s) +6s
  sequelize:perf inserting 10 rows x 359 ops/sec ±3.65% (72 runs sampled) (mean 0.002789s) +6s
  sequelize:perf Benchmark finished +0ms

(All updates)

Owens-MacBook-Pro:sequelize owen$ DIALECT=postgres sequelize-benchmark
  sequelize:perf Using postgres DIALECT. +0ms
(node:67244) DeprecationWarning: Using the automatically created return value from client.query as an event emitter is deprecated and will be removed in pg@7.0. Please see the upgrade guide at https://node-postgres.com/guides/upgrading
  sequelize:perf Env ready +224ms
  sequelize:perf Starting findAll +5s
  sequelize:perf finding 1500 rows x 1.81 ops/sec ±4.62% (14 runs sampled) (mean 0.552731s) +8s
  sequelize:perf finding(raw) 1500 rows x 1.91 ops/sec ±1.34% (14 runs sampled) (mean 0.524339s) +8s
  sequelize:perf finding(plain) 1500 rows x 1.86 ops/sec ±1.22% (14 runs sampled) (mean 0.536404s) +8s
  sequelize:perf finding 1500 rows with join x 1.73 ops/sec ±1.55% (13 runs sampled) (mean 0.577722s) +8s
  sequelize:perf finding 1500 rows with join (heavy includes) x 1.59 ops/sec ±1.35% (12 runs sampled) (mean 0.628003s) +8s
  sequelize:perf finding 10 rows x 127 ops/sec ±0.97% (80 runs sampled) (mean 0.007863s) +6s
  sequelize:perf finding(raw) 10 rows x 131 ops/sec ±0.81% (82 runs sampled) (mean 0.007626s) +6s
  sequelize:perf finding(plain) 10 rows x 128 ops/sec ±0.95% (81 runs sampled) (mean 0.007783s) +6s
  sequelize:perf finding 10 rows with join x 118 ops/sec ±1.05% (76 runs sampled) (mean 0.008449s) +6s
  sequelize:perf Starting bulkCreate +93ms
  sequelize:perf inserting 10000 rows x 2.23 ops/sec ±1.65% (16 runs sampled) (mean 0.448327s) +7s
  sequelize:perf inserting 1000 rows x 20.87 ops/sec ±3.21% (52 runs sampled) (mean 0.047926s) +6s
  sequelize:perf inserting 10 rows x 323 ops/sec ±28.55% (77 runs sampled) (mean 0.003097s) +7s
  sequelize:perf Benchmark finished +0ms
```